### PR TITLE
Changed property throws accessor

### DIFF
--- a/src/contra.js
+++ b/src/contra.js
@@ -167,7 +167,7 @@
       var args = atoa(arguments);
       var type = args.shift();
       var et = evt[type];
-      if (type === 'error' && opts.throws !== false && !et) { throw args.length === 1 ? args[0] : args; }
+      if (type === 'error' && opts['throws'] !== false && !et) { throw args.length === 1 ? args[0] : args; }
       if (!et) { return thing; }
       evt[type] = et.filter(function emitter (listen) {
         if (opts.async) { debounce(listen, args, thing); } else { listen.apply(thing, args); }


### PR DESCRIPTION
YUI compressor currently fails with error :
"missing name after . operator"

This fixes it and allows it to compress correctly, with no errors
