### PR TITLE
fix broken require in shim.js

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -1,1 +1,1 @@
-require('./src/contra.shim.js');
+require('./contra.shim.js');


### PR DESCRIPTION
Browserify throws an error if you require('contra/shim') as described in the docs.